### PR TITLE
Support protoc-3.0.0-beta-4

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,7 +8,7 @@ Boot tasks for fetching google protobuf protoc binary and compiling proto file.
 ** Dependencies
 
 #+begin_src clojure
-  [boot-protobuf "0.1.2"] ;; latest release
+  [boot-protobuf "0.1.4"] ;; latest release
 #+end_src
 
 ** Usage

--- a/build.boot
+++ b/build.boot
@@ -9,7 +9,7 @@
 
 (require '[adzerk.bootlaces :refer :all])
 
-(def +version+ "0.1.3")
+(def +version+ "0.1.4")
 
 (task-options!
  pom {:project 'boot-protobuf

--- a/src/boot_protobuf.clj
+++ b/src/boot_protobuf.clj
@@ -10,7 +10,7 @@
    [me.raynes.fs.compression :as fs-compression]
    [me.raynes.conch.low-level :as sh]))
 
-(def version (or (boot/get-env :protobuf-version) "3.0.0-beta-3"))
+(def version (or (boot/get-env :protobuf-version) "3.0.0-beta-4"))
 
 (def platform
   (let [osname (System/getProperty "os.name")

--- a/src/boot_protobuf.clj
+++ b/src/boot_protobuf.clj
@@ -32,8 +32,16 @@
            version
            (case platform :mac "osx-x86_64"))))
 
-(defn protoc-bin-dir []
+(defn protoc-unzip-dir []
   (jio/file protoc-cache-dir (fs/base-name (protoc-bin-zipfile) ".zip")))
+
+(defn protoc-bin-dir []
+  "Looks up the protoc binary folder. From protoc-3.0.0-beta-4 on, the protoc binary resides in bin/"
+  (let [unzip-dir (protoc-unzip-dir)
+        protoc-bin-dir (jio/file unzip-dir "bin")]
+    (if (.exists protoc-bin-dir)
+      protoc-bin-dir
+      unzip-dir)))
 
 (defn protoc-bin-url []
   (java.net.URL.
@@ -45,7 +53,7 @@
 (defn fetch-protoc-bin []
   (let [zipfile    (protoc-bin-zipfile)
         cachedir   protoc-cache-dir
-        extractdir (protoc-bin-dir)
+        extractdir (protoc-unzip-dir)
         protoc     (jio/file (protoc-bin-dir) "protoc")]
     (when-not (.exists zipfile)
       (.mkdirs cachedir)


### PR DESCRIPTION
Support for protoc-3.0.0-beta-4 where the `protoc` binary from the downloaded zip has been moved to `bin/protoc`.
