### PR TITLE
Improve readme with dependencies for example

### DIFF
--- a/README.org
+++ b/README.org
@@ -14,6 +14,9 @@ Boot tasks for fetching google protobuf protoc binary and compiling proto file.
 ** Usage
 
 #+begin_src clojure
+  (set-env! :dependencies '[[com.google.protobuf/protobuf-java "3.0.0"] ;; needed to compile .proto to java
+                            [boot-protobuf "0.1.4"]])
+
   (require '[boot-protobuf :refer [compile-protobuf-java]])
 #+end_src
 


### PR DESCRIPTION
Adds a `set-env!` with the `protobuf-java` dependency to the readme, which unless I am mistaken is the minimal setup needed to compile a proto file
